### PR TITLE
fix: adapt test utils to pass `light.Verify`

### DIFF
--- a/node/full_client_test.go
+++ b/node/full_client_test.go
@@ -435,7 +435,9 @@ func TestCometBFTLightClientCompability(t *testing.T) {
 				continue
 			}
 
-			light.Verify(&trustedHeader, fixedValSet, &commit.SignedHeader, fixedValSet, 3*time.Hour, b.Time(), 10*time.Second, cmtmath.Fraction{Numerator: 2, Denominator: 1})
+			err = light.Verify(&trustedHeader, fixedValSet, &commit.SignedHeader, fixedValSet, 3*time.Hour, b.Time(), 10*time.Second, cmtmath.Fraction{Numerator: 2, Denominator: 1})
+			require.NoError(err, "failed to pass light.Verify()")
+
 			trustedHeader = commit.SignedHeader
 		}
 	})

--- a/types/utils.go
+++ b/types/utils.go
@@ -35,7 +35,7 @@ func GetRandomValidatorSetWithPrivKey() (*cmtypes.ValidatorSet, ed25519.PrivKey)
 	return &cmtypes.ValidatorSet{
 		Proposer: &cmtypes.Validator{PubKey: pubKey, Address: pubKey.Address()},
 		Validators: []*cmtypes.Validator{
-			{PubKey: pubKey, Address: pubKey.Address()},
+			{PubKey: pubKey, Address: pubKey.Address(), VotingPower: 1},
 		},
 	}, privKey
 }
@@ -124,6 +124,7 @@ func GetRandomNextHeader(header Header) Header {
 	nextHeader.BaseHeader.Time = uint64(time.Now().Add(1 * time.Second).UnixNano())
 	nextHeader.LastHeaderHash = header.Hash()
 	nextHeader.ProposerAddress = header.ProposerAddress
+	nextHeader.ValidatorHash = header.ValidatorHash
 	return nextHeader
 }
 
@@ -144,7 +145,7 @@ func GetRandomSignedHeaderWith(height uint64, dataHash header.Hash) (*SignedHead
 	signedHeader.Header.DataHash = dataHash
 	signedHeader.Header.ProposerAddress = valSet.Proposer.Address
 	signedHeader.Header.ValidatorHash = valSet.Hash()
-	signedHeader.Header.BaseHeader.Time = uint64(time.Now().Unix()) + height*10
+	signedHeader.Header.BaseHeader.Time = uint64(time.Now().UnixNano()) + height*10
 	commit, err := getCommit(signedHeader.Header, privKey)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
@AdityaSripal and I have been reviewing https://github.com/rollkit/rollkit/pull/1424. 
We found that the error returned from `light.Verify` was not being checked in the test code. 

After checking the error we got some errors wrt:
- Timestamps
- ValidatorHash
- VotingPower

However it seems changing some of the test utilts in `utils.go` causes test failures elsewhere in the repo. Haven't addressed the other test failures but wanted to share the diffs here which we made to make `light.Verify` pass the tests. 