### PR TITLE
change two defaults to fix go relayer compatibility

### DIFF
--- a/config/defaults.go
+++ b/config/defaults.go
@@ -9,7 +9,7 @@ const (
 	DefaultListenAddress = "/ip4/0.0.0.0/tcp/7676"
 	// Version is the current rollkit version
 	// Please keep updated with each new release
-	Version = "0.12.0"
+	Version = "0.38.5"
 )
 
 // DefaultNodeConfig keeps default values of NodeConfig

--- a/node/full_client.go
+++ b/node/full_client.go
@@ -751,7 +751,7 @@ func (c *FullClient) Status(ctx context.Context) (*ctypes.ResultStatus, error) {
 			EarliestAppHash:     cmbytes.HexBytes(initial.SignedHeader.AppHash),
 			EarliestBlockHeight: int64(initial.Height()),
 			EarliestBlockTime:   initial.Time(),
-			CatchingUp:          true, // the client is always syncing in the background to the latest height
+			CatchingUp:          false, // hard-code this to "false" to pass Go IBC relayer's legacy encoding check
 		},
 		ValidatorInfo: ctypes.ValidatorInfo{
 			Address:     validator.Address,


### PR DESCRIPTION
Fixes compatibility with the Go IBC relayer for the JTMB IBC PR https://github.com/rollkit/rollkit/pull/1424#issuecomment-1912989697